### PR TITLE
Fix up rustc-serialize to build against new rustc

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -2011,8 +2011,8 @@ macro_rules! read_primitive {
                 // re: #12967.. a type w/ numeric keys (ie HashMap<usize, V> etc)
                 // is going to have a string here, as per JSON spec.
                 Json::String(s) => match s.parse() {
-                    Some(f) => Ok(f),
-                    None => Err(ExpectedError("Number".to_string(), s)),
+                    Ok(f)  => Ok(f),
+                    Err(_) => Err(ExpectedError("Number".to_string(), s)),
                 },
                 value => Err(ExpectedError("Number".to_string(), format!("{}", value))),
             }
@@ -2049,8 +2049,8 @@ impl ::Decoder for Decoder {
                 // re: #12967.. a type w/ numeric keys (ie HashMap<usize, V> etc)
                 // is going to have a string here, as per JSON spec.
                 match s.parse() {
-                    Some(f) => Ok(f),
-                    None => Err(ExpectedError("Number".to_string(), s)),
+                    Ok(f)  => Ok(f),
+                    Err(_) => Err(ExpectedError("Number".to_string(), s)),
                 }
             },
             Json::Null => Ok(f64::NAN),
@@ -2482,8 +2482,9 @@ impl<'a, T: Encodable> fmt::Display for AsPrettyJson<'a, T> {
 }
 
 impl FromStr for Json {
-    fn from_str(s: &str) -> Option<Json> {
-        Json::from_str(s).ok()
+    type Err = ParserError;
+    fn from_str(s: &str) -> Result<Json, ParserError> {
+        Json::from_str(s)
     }
 }
 
@@ -3816,7 +3817,7 @@ mod tests {
         struct ArbitraryType(u32);
         let mut hm: HashMap<ArbitraryType, bool> = HashMap::new();
         hm.insert(ArbitraryType(1), true);
-        let mut mem_buf = Vec::new();
+        let mut mem_buf = string::String::new();
         let mut encoder = Encoder::new(&mut mem_buf as &mut fmt::Writer);
         let result = hm.encode(&mut encoder);
         match result.err().unwrap() {

--- a/src/json.rs
+++ b/src/json.rs
@@ -256,7 +256,7 @@ use unicode::str::Utf16Item;
 use Encodable;
 
 /// Represents a json value
-#[derive(Clone, PartialEq, PartialOrd, Show)]
+#[derive(Clone, PartialEq, PartialOrd, Debug)]
 pub enum Json {
     I64(i64),
     U64(u64),
@@ -298,7 +298,7 @@ pub enum ErrorCode {
     NotUtf8,
 }
 
-#[derive(Clone, Copy, PartialEq, Show)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum ParserError {
     /// msg, line, col
     SyntaxError(ErrorCode, usize, usize),
@@ -308,7 +308,7 @@ pub enum ParserError {
 // Builder and Parser have the same errors.
 pub type BuilderError = ParserError;
 
-#[derive(Clone, PartialEq, Show)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum DecoderError {
     ParseError(ParserError),
     ExpectedError(string::String, string::String),
@@ -317,7 +317,7 @@ pub enum DecoderError {
     ApplicationError(string::String)
 }
 
-#[derive(Copy, Show)]
+#[derive(Copy, Debug)]
 pub enum EncoderError {
     FmtError(fmt::Error),
     BadHashmapKey,
@@ -937,7 +937,7 @@ impl Json {
     }
 
     /// Borrow this json object as a pretty object to generate a pretty
-    /// representation for it via `Show`.
+    /// representation for it via `Display`.
     pub fn pretty(&self) -> PrettyJson {
         PrettyJson { inner: self }
     }
@@ -1142,7 +1142,7 @@ impl Index<usize> for Json {
 }
 
 /// The output of the streaming parser.
-#[derive(PartialEq, Clone, Show)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum JsonEvent {
     ObjectStart,
     ObjectEnd,
@@ -1157,7 +1157,7 @@ pub enum JsonEvent {
     Error(ParserError),
 }
 
-#[derive(PartialEq, Show)]
+#[derive(PartialEq, Debug)]
 enum ParserState {
     // Parse a value in an array, true means first element.
     ParseArray(bool),
@@ -1186,7 +1186,7 @@ pub struct Stack {
 /// StackElements compose a Stack.
 /// For example, Key("foo"), Key("bar"), Index(3) and Key("x") are the
 /// StackElements compositing the stack that represents foo.bar[3].x
-#[derive(PartialEq, Clone, Show)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum StackElement<'l> {
     Index(u32),
     Key(&'l str),
@@ -1194,7 +1194,7 @@ pub enum StackElement<'l> {
 
 // Internally, Key elements are stored as indices in a buffer to avoid
 // allocating a string for every member of an object.
-#[derive(PartialEq, Clone, Show)]
+#[derive(PartialEq, Clone, Debug)]
 enum InternalStackElement {
     InternalIndex(u32),
     InternalKey(u16, u16), // start, size
@@ -2508,7 +2508,7 @@ mod tests {
     use std::num::Float;
     use std::string;
 
-    #[derive(RustcDecodable, Eq, PartialEq, Show)]
+    #[derive(RustcDecodable, Eq, PartialEq, Debug)]
     struct OptionData {
         opt: Option<usize>,
     }
@@ -2535,20 +2535,20 @@ mod tests {
                                 ExpectedError("Number".to_string(), "false".to_string()));
     }
 
-    #[derive(PartialEq, RustcEncodable, RustcDecodable, Show)]
+    #[derive(PartialEq, RustcEncodable, RustcDecodable, Debug)]
     enum Animal {
         Dog,
         Frog(string::String, isize)
     }
 
-    #[derive(PartialEq, RustcEncodable, RustcDecodable, Show)]
+    #[derive(PartialEq, RustcEncodable, RustcDecodable, Debug)]
     struct Inner {
         a: (),
         b: usize,
         c: Vec<string::String>,
     }
 
-    #[derive(PartialEq, RustcEncodable, RustcDecodable, Show)]
+    #[derive(PartialEq, RustcEncodable, RustcDecodable, Debug)]
     struct Outer {
         inner: Vec<Inner>,
     }
@@ -3438,7 +3438,7 @@ mod tests {
     fn test_hashmap_with_enum_key() {
         use std::collections::HashMap;
         use json;
-        #[derive(RustcEncodable, Eq, Hash, PartialEq, RustcDecodable, Show)]
+        #[derive(RustcEncodable, Eq, Hash, PartialEq, RustcDecodable, Debug)]
         enum Enum {
             Foo,
             #[allow(dead_code)]


### PR DESCRIPTION
Only real substantial change that's not just switching names/types around was in the base64 code, where since iterators aren't copyable anymore I had to restructure it slightly. Everything tests clean though.