### PR TITLE
Revert "Work around the std::path reform."

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -14,7 +14,7 @@
 Core encoding and decoding interfaces.
 */
 
-use std::old_path as path;
+use std::path;
 use std::rc::Rc;
 use std::cell::{Cell, RefCell};
 use std::sync::Arc;


### PR DESCRIPTION
This reverts commit cfd9e26258233090fae63428fbb56d70c1504236.

----------------------

This change does not compile with the latest rust snapshot.