### PR TITLE
Fixed return type and removed unused features

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -923,10 +923,9 @@ impl Json {
         let contents = {
             let mut c = Vec::new();
             match rdr.read_to_end(&mut c) {
-                Ok(c)  => c,
+                Ok(_)  => c,
                 Err(e) => return Err(io_error_to_error(e))
             }
-            c
         };
         let s = match str::from_utf8(&contents).ok() {
             Some(s) => s,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 
 //! Support code for encoding and decoding types.
 
-#![feature(core, io, std_misc, path)]
+#![feature(core, std_misc)]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/rustc-serialize/")]


### PR DESCRIPTION
The Ok(c) was shadowing the return Vector and resulted in unmatched return types.