### PR TITLE
Control characters inside string should be forbidden

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -1669,13 +1669,9 @@ impl<T: Iterator<Item = char>> Parser<T> {
                         self.bump();
                         return Ok(res);
                     },
-                    Some(c) => {
-                        if c.is_control() {
-                            return self.error(ControlCharacterInString)
-                        } else {
-                            res.push(c)
-                        }
-                    },
+                    Some(c) if c.is_control() =>
+                        return self.error(ControlCharacterInString),
+                    Some(c) => res.push(c),
                     None => unreachable!()
                 }
             }


### PR DESCRIPTION
In accordance with standard JSON string is a sequence of zero or more Unicode characters (except `"` or `\` or **control character**) and backslash escapes. This pull request forbids the use of unescaped control characters within a string.