### PR TITLE
Update to rustc 1.0.0-dev (e46610966 2015-03-17) (built 2015-03-17)

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -574,7 +574,7 @@ impl Decodable for path::PathBuf {
     }
     #[cfg(windows)]
     fn decode<D: Decoder>(d: &mut D) -> Result<path::PathBuf, D::Error> {
-        use std::os::windows::OsStringExt;
+        use std::os::windows::ffi::OsStringExt;
         let bytes: Vec<u16> = try!(Decodable::decode(d));
         let s: OsString = OsStringExt::from_wide(&bytes);
         Ok(path::PathBuf::new(&s))


### PR DESCRIPTION
std::os::windows::OsStringExt moved to std::os::windows::ffi::OsStringExt.