### PR TITLE
Beta fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ support for hex, base64, and json encoding and decoding.
 """
 
 [dev-dependencies]
-rand = "0.2"
+rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 
 //! Support code for encoding and decoding types.
 
-#![feature(convert)]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/rustc-serialize/")]

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -570,14 +570,18 @@ impl Decodable for path::PathBuf {
         use std::os::unix::prelude::*;
         let bytes: Vec<u8> = try!(Decodable::decode(d));
         let s: OsString = OsStringExt::from_vec(bytes);
-        Ok(path::PathBuf::from(s))
+        let mut p = path::PathBuf::new();
+        p.push(s);
+        Ok(p)
     }
     #[cfg(windows)]
     fn decode<D: Decoder>(d: &mut D) -> Result<path::PathBuf, D::Error> {
         use std::os::windows::prelude::*;
         let bytes: Vec<u16> = try!(Decodable::decode(d));
         let s: OsString = OsStringExt::from_wide(&bytes);
-        Ok(path::PathBuf::from(s))
+        let mut p = PathBuf::new();
+        p.push(s);
+        Ok(p)
     }
 }
 


### PR DESCRIPTION
rustc-serialize is one of the most heavily depended upon crates; 125 reverse dependencies when I last checked. Getting it compiling on the beta channel will make it a lot easier to get other crates that depend on it compiling on the beta channel.

To do so, we need to remove its dependency on the `convert` feature, which is waiting on rust-lang/rfcs#529 that seems to be in rapid development. We can do that by just reverting the commit that adds support to this feature, and then add it back later once convert is no longer feature-gated.

The other fix is to simply update the dev dedpendency on `rand`, to a newer version that depends on a newer `log`. `log` also doesn't quite build on beta channel yet, but there is already a commit in the repository that fixes that (rust-lang/log@93fac65cd), it just needs to be version bumped and released.