### PR TITLE
Fix compilation error on Windows

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -579,7 +579,7 @@ impl Decodable for path::PathBuf {
         use std::os::windows::prelude::*;
         let bytes: Vec<u16> = try!(Decodable::decode(d));
         let s: OsString = OsStringExt::from_wide(&bytes);
-        let mut p = PathBuf::new();
+        let mut p = path::PathBuf::new();
         p.push(s);
         Ok(p)
     }


### PR DESCRIPTION
Introduced in #87

Better continuous integration would be great. It's the second time in three days that one of the official crates doesn't compile on Windows.
