### PR TITLE
Speed up base64 encoding 2x by using mutating iterators and better preallocation

### DIFF
--- a/benches/base64.rs
+++ b/benches/base64.rs
@@ -27,3 +27,22 @@ fn bench_from_base64(b: &mut Bencher) {
     b.bytes = sb.len() as u64;
 }
 
+
+#[bench]
+fn bench_to_base64_large(b: &mut Bencher) {
+    let s: Vec<_> = (0..10000).map(|i| ((i as u32 * 12345) % 256) as u8).collect();
+    b.iter(|| {
+        s.to_base64(STANDARD);
+    });
+    b.bytes = s.len() as u64;
+}
+
+#[bench]
+fn bench_from_base64_large(b: &mut Bencher) {
+    let s: Vec<_> = (0..10000).map(|i| ((i as u32 * 12345) % 256) as u8).collect();
+    let sb = s.to_base64(STANDARD);
+    b.iter(|| {
+        sb.from_base64().unwrap();
+    });
+    b.bytes = sb.len() as u64;
+}


### PR DESCRIPTION
Iterators are really fast. So is using mutation instead of pushing.

Before:

    test bench_to_base64         ... bench:       356 ns/iter (+/- 10) = 424 MB/s
    test bench_to_base64_large   ... bench:     21378 ns/iter (+/- 1030) = 467 MB/s

After:

    test bench_to_base64         ... bench:       207 ns/iter (+/- 10) = 729 MB/s
    test bench_to_base64_large   ... bench:     10900 ns/iter (+/- 709) = 917 MB/s

[Diff best seen ignoring whitespace.](https://github.com/rust-lang/rustc-serialize/pull/119/files?w=1)