### PR TITLE
Mention Serde in rustc-serialize docs

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -227,6 +227,14 @@
 //!     // bar: baz (string)
 //!     // foo: 13 (u64)
 //! }
+//!
+//! # The status of this library
+//!
+//! While this library is the standard way of working with JSON in Rust,
+//! there is a next-generation library called Serde that's in the works
+//! (it's faster, overcomes some design limitations of rustc-serialize and has more features).
+//! You might consider using it when starting new project or evaluating Rust JSON performance.
+//!
 //! ```
 
 use self::JsonEvent::*;


### PR DESCRIPTION
New Rust users often use rustc-serialize simply because it's the official package and they never heard of Serde. Mentioning Serde in rustc-serialize docs will allow them to consider a more efficient and feature-wise package.

One use case is people coming to test Rust performance and seeing it as a slow language because they're using an older JSON package (cf. http://www.reddit.com/r/rust/comments/38s1n3/why_is_rust_much_slower_and_memory_consuming_than/).