### PR TITLE
added fix for encoding and decoding phantom data

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -3883,6 +3883,23 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_decode_phantom_data() {
+        use std::marker::PhantomData;
+
+        #[derive(Debug, RustcDecodable, RustcEncodable, Eq, PartialEq)]
+        struct Foo<P> {
+            phantom_data: PhantomData<P>
+        }
+        
+        let f: Foo<u8> = Foo {
+            phantom_data: PhantomData
+        };
+        let s = super::encode(&f).unwrap();
+        let d: Foo<u8> = super::decode(&s).unwrap();
+        assert_eq!(f, d);
+    }
+
+    #[test]
     fn test_bad_json_stack_depleted() {
         use json;
         #[derive(Debug, RustcDecodable)]

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -512,8 +512,8 @@ impl<T:Decodable> Decodable for Option<T> {
 }
 
 impl<T> Encodable for PhantomData<T> {
-    fn encode<S: Encoder>(&self, _s: &mut S) -> Result<(), S::Error> {
-        Ok(())
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_nil()
     }
 }
 


### PR DESCRIPTION
This change fixes #114.

 I was running into the same issue, and noticed that PhantomData's implementation of `encode` was just returning `Ok`, even though it was not actually emitting anything. This caused the outputted JSON to have an invalid syntax.