### PR TITLE
Make rustc-serialize fully portable

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1356,7 +1356,7 @@ array! {
 }
 
 impl Encodable for path::Path {
-    #[cfg(target_os = "redox")]
+    #[cfg(not(any(unix, windows)))]
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
         self.as_os_str().to_str().unwrap().encode(e)
     }
@@ -1380,7 +1380,7 @@ impl Encodable for path::PathBuf {
 }
 
 impl Decodable for path::PathBuf {
-    #[cfg(target_os = "redox")]
+    #[cfg(not(any(unix, windows)))]
     fn decode<D: Decoder>(d: &mut D) -> Result<path::PathBuf, D::Error> {
         let string: String = try!(Decodable::decode(d));
         let s: OsString = OsString::from(string);


### PR DESCRIPTION
This PR makes it so that rustc-serialize compiles and has reasonable behavior on all platforms.

Even though rustc-serialize is deprecated, it's a cornerstone of the Rust crates ecosystem. Popular projects such as RLS and rust-crypto depend on it. Not supporting all platforms hampers the growth of new platforms (WebAssembly, SGX, etc.) in favor of existing platforms.

This PR should be a one-time fix for all future platforms that Rust might support in the future.

Fixes #190 
Fixes #191
Fixes #194